### PR TITLE
推送节点配置修正

### DIFF
--- a/bizwechat.html
+++ b/bizwechat.html
@@ -110,7 +110,7 @@ RED.nodes.registerType('bizwechat-pushbear', {
     title: {
       value: ''
     },
-    description: {
+    introduction: {
       value: ''
     },
     longPath: {
@@ -140,7 +140,7 @@ RED.nodes.registerType('bizwechat-template', {
     title: {
       value: ''
     },
-    description: {
+    introduction: {
       value: ''
     },
     longPath: {
@@ -258,8 +258,8 @@ RED.nodes.registerType('bizwechat-template', {
     <input type="text" id="node-input-title" placeholder="发送信息的标题">
   </div>
   <div class="form-row">
-    <label for="node-input-description"><i class="icon-tag"></i>内容</label>
-    <textarea id="node-input-description" placeholder="发送信息的内容(MarkDown语法)" style="width: 70%; height:200px;"></textarea>
+    <label for="node-input-introduction"><i class="icon-tag"></i>描述</label>
+    <textarea id="node-input-introduction" placeholder="卡片上面的描述,用户一些从正文正提取信息不还好看的情况下" style="width: 70%; height:200px;"></textarea>
   </div>
   <div class="form-row">
     <label for="node-input-longPath"><i class="icon-tag"></i>长链接</label>
@@ -378,8 +378,8 @@ RED.nodes.registerType('bizwechat-template', {
     <input type="text" id="node-input-title" placeholder="网页内容的标题">
   </div>
   <div class="form-row">
-    <label for="node-input-description"><i class="icon-tag"></i>内容</label>
-    <textarea id="node-input-description" placeholder="网页内容的文本(MarkDown语法)" style="width: 70%; height:200px;"></textarea>
+    <label for="node-input-introduction"><i class="icon-tag"></i>描述</label>
+    <textarea id="node-input-introduction" placeholder="卡片上面的描述,用户一些从正文正提取信息不还好看的情况下" style="width: 70%; height:200px;"></textarea>
   </div>
   <div class="form-row">
     <label for="node-input-longPath"><i class="icon-tag"></i>长链接</label>

--- a/bizwechat.html
+++ b/bizwechat.html
@@ -259,7 +259,7 @@ RED.nodes.registerType('bizwechat-template', {
   </div>
   <div class="form-row">
     <label for="node-input-introduction"><i class="icon-tag"></i>描述</label>
-    <textarea id="node-input-introduction" placeholder="卡片上面的描述,用户一些从正文正提取信息不还好看的情况下" style="width: 70%; height:200px;"></textarea>
+    <textarea id="node-input-introduction" placeholder="卡片上面的描述,用户一些从正文正提取信息不好看的情况下" style="width: 70%; height:200px;"></textarea>
   </div>
   <div class="form-row">
     <label for="node-input-longPath"><i class="icon-tag"></i>长链接</label>
@@ -282,7 +282,7 @@ RED.nodes.registerType('bizwechat-template', {
         <dd>消息接收的用户，多个可以使用|分开，例如：xxx|xxx|xxx,不填写默认推送所有人</dd>
         <dt class="optional">introduction <span class="property-type">string</span>
         </dt>
-        <dd>卡片上面的描述,用户一些从正文正提取信息不还好看的情况下</dd>
+        <dd>卡片上面的描述,用户一些从正文正提取信息不好看的情况下</dd>
         
 
     </dl>
@@ -379,7 +379,7 @@ RED.nodes.registerType('bizwechat-template', {
   </div>
   <div class="form-row">
     <label for="node-input-introduction"><i class="icon-tag"></i>描述</label>
-    <textarea id="node-input-introduction" placeholder="卡片上面的描述,用户一些从正文正提取信息不还好看的情况下" style="width: 70%; height:200px;"></textarea>
+    <textarea id="node-input-introduction" placeholder="卡片上面的描述,用户一些从正文正提取信息不好看的情况下" style="width: 70%; height:200px;"></textarea>
   </div>
   <div class="form-row">
     <label for="node-input-longPath"><i class="icon-tag"></i>长链接</label>

--- a/bizwechat.js
+++ b/bizwechat.js
@@ -110,7 +110,7 @@ module.exports = RED => {
 
           // 合并值,未细想
           for (const key in config) { if (config[key] != '' && config[key] != null) { data[key] = config[key] } }
-          data.description = data.description || data.payload
+          data.description = data.payload || data.description
           data.touser = data.touser || '@all'
           data.url = data.url || 'https://bbs.iobroker.cn'
 
@@ -140,7 +140,7 @@ module.exports = RED => {
 
           // 合并值,未细想
           for (const key in config) { if (config[key] != '' && config[key] != null) { data[key] = config[key] } }
-          data.description = data.description || data.payload
+          data.description = data.payload || data.description
 
           // 网页内容 存储
 

--- a/lib/WeChat.js
+++ b/lib/WeChat.js
@@ -223,10 +223,10 @@ class WechatClass {
         const { title, introduction, touser, html } = data
         // 发送主动消息
         if (introduction) { // 如果用户已经自己定义简介,测试用用户提供的
-          data.description = introduction
+          data.introduction = introduction
         } else {
           const noHtml = html.replace(/<\/?[^>]*>/g, '')
-          data.description = noHtml
+          data.introduction = noHtml
         }
         // 构建卡片发送消息格式
         const { agentid } = this.config
@@ -234,7 +234,7 @@ class WechatClass {
           msgtype: 'textcard',
           agentid,
           touser,
-          textcard: { title, description: data.description, url: data.url }
+          textcard: { title, description: data.introduction, url: data.url }
         }
 
         await this.pushMessage(sendData)


### PR DESCRIPTION
原状态：推送节点的内容，如果留空，则根据payload内容自动生成，这样的文本卡片不好看，很多时候看起来像乱码。
如果在此处填写描述（description），那么将会覆盖掉payload内容，导致推送的正文内容变为描述内容。
我理解正确的逻辑应为这样的：
现状态：推送节点的输入框，原文为“内容”，修改为“描述”，即description。如果留空，则按照payload内容生成。如果填写内容，则description为填写的内容，且正文仍保留payload内容，不会被此处填写的内容覆盖。
以上均经过个人测试，工作正常。